### PR TITLE
Add ASC-41

### DIFF
--- a/Accepted/asc041.md
+++ b/Accepted/asc041.md
@@ -1,0 +1,55 @@
+﻿#### **Title**
+Add read position parameters to `spectrophotometry` instruction
+
+#### **Authorship**
+Yang Choo <yang@transcriptic.com>
+
+#### **Motivation**
+The z-axis positioning of the probe has a critical impact on the read values returned. This is a common feature that's exposed in various plate-readers, and a common paradigm is to either manually set the probe-height or allow that to be automatically determined based on a device-specific algorithm.
+
+
+#### **Proposal**
+We propose adding optional mode_parameters to the `spectrophotometry` instruction to address the need outlined in the motivation.
+
+The parameters outlined closely follow conventions from ASC-026.
+
+```
+{
+  "op": "spectrophotometry",
+  …,
+  "groups": [
+    {
+        /** optional params for all modes */
+        "mode_params": {
+          /** all params below are optional */
+          "read_position": Enum("top", "bottom"),
+          "position_z": {
+            "manual": {
+                "displacement": Length,  // displacement of probe from reference. E.g. if probe is below reference, displacement is negative
+                "reference": Enum("plate_bottom", "plate_top", "well_bottom", "well_top")
+              },
+            "calculated_from_wells": {
+                "wells": List(wells),
+                "heuristic": Enum("max_mean_read_without_saturation", "closest_distance_without_saturation")
+            }
+        }
+    }
+  ]
+}
+```
+
+#### **Execution**
+The `position_z` parameters control the z-axis positioning of the probe. When set to `manual`, the probe will be positioned the stated length from the reference point.
+
+If `calculated_from_wells` is specified, the z-axis distance of the probe will be calculated from the selected `wells` using the specified `heuristic`.
+
+`closest_distance_without_saturation` refers to the z-position which is closest to the reference without obtaining saturated values for any of the specified wells.
+
+`max_mean_read_with_saturation` refers to the z-position which corresponds to the maximum signal from the mean readings per height, excluding heights with saturated readings. If there is a tie amongst the mean values, the closest distance to the reference is taken.
+
+Only either `manual` or `calculated_from_wells` should be specified.
+
+As always, all non-specified parameters will be interpreted as not critical for the experiment execution and will be left to the vendor to decide on the appropriate defaults.
+
+#### **Compatibility**
+This is entirely backwards compatible as only new parameters are added. Vendors should indicate if they are unable to respect any of the parameters.


### PR DESCRIPTION
This adds ASC-41 (read position parameters to `spectrophotometry` instruction) to the Accepted phase