### PR TITLE
Add ASC proposal for `Agitate`

### DIFF
--- a/Proposed/asc044.md
+++ b/Proposed/asc044.md
@@ -1,0 +1,41 @@
+#### **Title**
+New instruction: `agitate`
+
+#### **Authorship**
+Asuka Ota <asuka.ota@strateos.com>
+
+Varun Kanwar <varunkanwar1@gmail.com>
+
+#### **Motivation**
+Mixing samples via agitation is a common experimental process. The agitation can be indirect, by vortexing, inverting, and rolling sample containers, or direct, through the use of a stir bar. An instruction dedicated to agitating samples in these modes is currently lacking in Autoprotocol.
+
+#### **Proposal**
+We propose a new instruction to agitate samples in containers of various sizes and shape-formats. This is acheived by specifying agitation modes, and corresponding mode-specific parameters where necessary. The `vortex` mode refers to agitation by oscillating samples in a circular motion at a specified frequency. `invert` involves the mixing of samples by slowly inverting containers up-side-down at a specified speed. `roll` refers to mixing by rolling a container sideways on a roller at a specified speed; it is often applicable for larger volume containers. `stir_bar` applies a magnetic field to spin a magnetic stir bar and is introduced directly into the sample.
+
+```
+{
+  “op”: “agitate”,
+  /* 
+   * Sample container. Some restrictions apply to container shapes and 
+   * sizes--for example, `invert` and `roll` typically cannot be applied
+   * to wellplates. The implementer is responsible for enforcing size,
+   * shape, and speed limitations based on devices available to the
+   * execution environment.
+   */
+  “object”: Container,
+  “duration”: Time,
+  “speed”: Frequency,
+  “mode”: Enum(“vortex”, “invert”, “roll”, “stir_bar”),
+  /* Mode-specific parameters for the ‘stir_bar’ mode */
+  “mode_params”: {
+    “wells”: WellGroup
+    “bar_shape”: String
+    “bar_length”: Unit or String
+  }
+  /* Temperature at which sample is being agitated. Optional */
+  “temperature”: Temperature,
+}
+```
+
+#### **Compatibility**
+This is a new instruction; there are no compatibility issues.


### PR DESCRIPTION
This ASC proposes the addition of an `Agitate` instruction. Mixing samples via agitation is a common experimental process. The agitation can be indirect, by vortexing, inverting, and rolling sample containers, or direct, through the use of a stir bar.