### PR TITLE
Add ASC proposal for `Evaporate`

### DIFF
--- a/Proposed/asc045.md
+++ b/Proposed/asc045.md
@@ -1,0 +1,90 @@
+#### **Title**
+New instruction: `evaporate`
+
+#### **Authorship**
+Asuka Ota <asuka.ota@strateos.com>
+
+Varun Kanwar <varunkanwar1@gmail.com>
+
+#### **Motivation**
+Evaporation is used to remove or isolate liquid solvent(s) and/or moisture from a mixture of compounds in a container under specified conditions. This process is often employed in chemical synthesis to precipitate or concentrate target compounds from a sample.
+
+#### **Proposal**
+We propose adding an `evaporate` instruction, with evaporation `mode`s parameterized by their `mode_params`. Samples can be `rotate`d in a flask, `centrifuge`d, and `vortexed`, or can have an inert gas blown across their surface via the `blowdown` mode.
+
+```
+{
+  “op”: “evaporate”,
+  “object”: Container,
+  /* Duration to incubate the sample in the evaporator */
+  “duration”: Time
+  /*
+   * Temperature at which the container is incubated. If specified, the device
+   * in question will be brought up to temperature prior to the start of
+   * the instruction
+   */
+  “evaporator_temperature”: Temperature
+  /* Method applied to agitate the sample container */
+  “mode”: Enum(“rotate”, “centrifuge”, “vortex”, “blowdown”),
+  /* Parameters for the `rotate` mode */
+  “mode_params”: {
+    /*
+     * Volume of the rotating flask that functions as the evaporation chamber.
+     * Typically, the volume of the flask is at least double that of its
+     * contents, such that there is ample surface area to facilitate
+     * speedy evaporation
+     */
+    “flask_volume”: Volume,
+    /* Speed at which flask is rotated */
+    “speed”: Frequency
+    /* Pressure applied to sample flask. Must be lower than ambient pressure */
+    “vacuum_pressure”: Pressure
+    /*
+     * Temperature of the condenser chamber, where the evaporated material
+     * is collected and returned to liquid phase
+     */
+    “condenser_temperature”: Temperature
+  }
+  /* Parameters for the `centrifuge` mode */
+  “mode_params”: {
+    /* Speed at which container is centrifuged */
+    “spin_acceleration”: Acceleration
+    /* Pressure applied to sample flask. Must be lower than ambient pressure */
+    “vacuum_pressure”: Pressure
+    /*
+     * Temperature of the condenser chamber, where the evaporated material
+     * is collected and returned to liquid phase
+     */
+    “condenser_temperature”: Temperature
+  }
+  /* Parameters for the `vortex` mode */
+  “mode_params”: {
+    /* Speed at which the sample container is vortexed */
+    “vortex_speed”: Frequency
+    /* Pressure applied to sample flask. Must be lower than ambient pressure */
+    “vacuum_pressure”: Pressure
+    /*
+     * Temperature of the condenser chamber, where the evaporated material
+     * is collected and returned to liquid phase
+     */
+    “condenser_temperature”: Temperature
+  }
+  /* Parameters for the `blowdown` mode */
+  “mode_params”: {
+    /* The inert gas blown on the sample surface to facilitate evaporation */
+    "gas": Enum(“nitrogen”, “argon”, “helium”)
+    /* Rate at which gas is blown on the sample surface */
+    “blow_rate”: Flowrate,
+    /* Speed at which container is vortexed during evaporation */
+    “vortex_speed”: Frequency
+  }
+}
+```
+
+#### **Execution**
+The `mode` and associated `mode_params` specified determine the selection
+of executig device. It is the responsibility of the implementer to
+select an evaporator capable of executing the instruction.
+
+#### **Compatibility**
+This is a new instruction; there are no compatibility issues with existing instructions.

--- a/Proposed/asc045.md
+++ b/Proposed/asc045.md
@@ -83,8 +83,7 @@ We propose adding an `evaporate` instruction, with evaporation `mode`s parameter
 
 #### **Execution**
 The `mode` and associated `mode_params` specified determine the selection
-of executig device. It is the responsibility of the implementer to
-select an evaporator capable of executing the instruction.
+of device. Vendor specific implementation will determine the availability, and default values of these parameters.
 
 #### **Compatibility**
 This is a new instruction; there are no compatibility issues with existing instructions.


### PR DESCRIPTION
This ASC proposes the addition of an `Evaporate` instruction, to facilitate the removal or isolation of liquid solvents and/or moisture from a mixture of compounds.