### PR TITLE
Add ASC proposal for `LCMS`

### DIFF
--- a/Proposed/asc046.md
+++ b/Proposed/asc046.md
@@ -1,0 +1,221 @@
+#### **Title**
+New instruction: `lcms`
+
+#### **Authorship**
+Asuka Ota <asuka.ota@strateos.com>
+
+Varun Kanwar <varunkanwar1@gmail.com>
+
+#### **Motivation**
+Liquid chromatography-mass spectrometry  is a commonly used technique in analytical chemistry, whereby the physical separation function of chromatography and the sample identification capability of mass spectrometry are combined to separate and identify analytes from a liquid sample containing a mixture of compounds. This is a coupled process, whereby a small portion of the eluate produced from chromatographic separation is directed to the mass spectrometer for identification, while the rest can optionally be collected as separated fractions.
+
+#### **Proposal**
+We propose adding an `lcms` instruction to represent the coupled liquid chromatography-mass spectrometry technique in Autoprotocol.
+
+`liquid_chromatography` parameters control the isolation of the target analyte based on its interaction with the `stationary_phase` present in the `column`, and with the `buffers` that constitute the mobile phase. The composition of the mobile phase can be varied via the `gradient`, which represents the relative volumes of buffers present at different time points during the experiment.
+
+A small portion of the eluted fractions flow at a specified `ms_flow_rate` to the mass spectrometer, where they are evaporated and ionized before mass analysis. Parameters under `ionization` and `analysis` allow for fine-grained control over their respective processes. For example, `ion_mode` controls whether the evaporated eluate is protonated (positive) or deprotonated (negative), and `detection_mode` allows the user to detect signals either in a `mass_range`, or at a specific `mass`.
+
+Isolated fractions can optionally be collected if a UV module is present. Eluates are collected when their absorbance values exceed the `absorbance_threshold` at the specified `detection_wavelength`, and their mass intensity exceeds a specified `mass_threshold`.
+
+
+```
+{
+  "op": "lcms",
+  "object": List(Well) or WellGroup,
+  /* 
+   * `lcms` produces pressure, mass spectrometry and potentially UV absorbance
+   * data
+   */
+  “dataref”: String
+  /* Parameters for `liquid_chromatography` */
+  “liquid_chromatography”: {
+    /* The amount of liquid sample injected into the device */
+    "injection_volume": Volume
+    “num_injections”: Int
+    /*
+     * Temperature at which the autosampler is kept at during the run.
+     * Optional; should default to ambient temperature.
+     */
+    "autosampler_temperature": Temperature 
+    /*
+     * The stationary phase used in liquid chromatography to separate the
+     * target molecule 
+     */
+    "stationary_phase": {
+      “column”: ColumnType or String
+      “pre_column”: ColumnType or String
+    }
+    /* 
+     * The temperature of the column. Optional, should default to ambient
+     * temperature.
+     */
+    "column_temperature": Temperature
+    /*
+     * Buffers that constitute the mobile phase. A minimum of two and
+     * a maximum of four buffers is allowed.
+     */
+    "buffers": {
+      "a": String, 
+      "b": String, 
+      "c": String,  // Optional
+      "d": String   // Optional
+    }
+    /* Gradient method to separate analyte from a mixture */
+    "gradient": List(
+      {
+        "time": Time,
+        "ratio_a": Decimal,  // 0 to 1
+        "ratio_b": Decimal,
+        "ratio_c": Decimal,
+        "ratio_d": Decimal,
+        "flowrate": Flowrate
+      }
+    ),
+    /* 
+     * The initial flowrate of the mobile phase at time 0. 
+     * Note that if backpressure of the column exceeds the device 
+     * specification, the specified flowrate cannot be sustained.
+     */
+    "initial_flowrate": Flowrate
+    /*
+     * Rate at which the flowrate is adjusted from one value to 
+     * another. Also known as flow ramp rate.
+     */
+    "flow_acceleration": Acceleration
+    /* Needle cleaning after sample injection. Optional, defaults to true. */
+    “needle_wash”: Boolean
+  },
+  /* Parameters for `mass_spectrometry` */
+  “mass_spectrometry” : {    
+    /* Monoisotopic mass of the target molecule */
+    "target_mass": Mass
+    /* 
+     * Flow rate of sample entering the mass spectrometer. Usually between
+     * 0.05-2:mL/min.  
+     */
+    "ms_flow_rate": Flowrate
+    /* Parameters for ionizing the input sample */
+    “mass_ionization”: {
+      /* Ion source(s) used to ionize sample */
+      "ion_source": Enum("ESI","APCI","APPI","MMI")
+      "capillary_temperature": Temperature,
+      "vaporizer_temperature": Temperature
+      /* Gas used to assist sample nebulization */
+      "sheath_gas_flowrate": Flowrate,
+      /* Gas used to remove solvent from sample ions */
+      "auxiliary_gas_flowrate": Flowrate/Float,
+      /* Also known as capillary voltage. Usually between 3-5 kV.       
+      "ionization_voltage": Voltage,
+      /*
+       * Polarity of the ionization mode. This depends on 
+       * the column, analyte and solvent used in the protocol.
+       */
+      "ion_mode": Enum("positive","negative","dual")         
+      /*
+       * `fragmentor_voltage` regulates the speed at which the ions pass
+       * through the capillary into the mass analyzer. 
+       */
+      "fragmentor_voltage": Voltage
+    },
+    /* Parameters for “mass_analysis” */
+    "mass_analysis":    {
+      /*
+       * Mass analyzers used to distinguish ions based on 
+       * their mass to charge (m/z) ratio
+       */
+      "mass_analyzer": Enum(
+        "quad",
+        "tof",
+        "linear_ion_trap",
+        "orbital_ion_trap",
+        "q_tof",
+        "tof_tof"
+      ),
+      /* 
+       * Methods used to fragment selected ions in tandem 
+       * mass spectrometry (MS/MS). `CID` and `IRMPD` are 
+       * vibrational, while the rest are radical-induced methods.
+       */
+      "dissociation_method": Enum("CID", "IRMPD", "EDD", "ECD", "ETD", "EPD")
+    },
+    /* parameters for “mass_detection” */    
+    "mass_detection": {
+      /*
+       * `full_scan` scans samples in a mass range, while     
+       * "single_ion_monitoring" detects samples with a 
+       * specific mass.
+       */
+      "detection_mode: Enum(
+        “full_scan”,
+        "multiple_reaction_monitoring", 
+        "single_ion_monitoring"
+      ),
+      /*
+       * Screened mass range. Optional. If unspecified, will be resolved 
+       * automatically based on the target mass and device used.
+       */
+      "scan_range": List(
+        {
+          min: Mass,
+          max: Mass
+        }
+      ),
+      /*
+       * Step size for detection across the `scan_range`. The implementor
+       * must ensure this value is valid for available instruments; this value
+       * cannot be less than the mass resolution of the instrument.
+       */
+      "step_size": Float
+      /* Signal multiplier gain value. Optional */
+      "gain": Float
+    }
+  },
+  /*
+   * Parameters for uv detection, which can be used for fraction collection.
+   * This block is optional, and relies on the presence of a UV module
+   * on the device
+   */
+  "uv_detection": {
+    /*
+     * UV absorbance intensity (interpreted in absorbance units) threshold
+     * to trigger fraction collection, or to detect peaks.
+     */
+    "uv_threshold": mAU
+    /* The end point of data collection */
+    "stop_time": Time
+    /*
+     * Wavelength monitored to detect the presence of analyte in 
+     * a sample
+     */
+    "detection_wavelength": List[Wavelength]
+    /*
+     * Reference wavelength used to adjust for baseline signal 
+     * drift due to RI effects. Default can be `Automatic`. 
+     * Optional
+     */
+    "reference_wavelength":  List[Wavelength]
+    “fraction_collection”: {
+      "destinations": List(Well) or Wellgroup,
+      /*
+       * min retention time at which fraction collection 
+       * could be triggered. Default is `0: minutes`.
+       */
+      “collection_start_time”: Time,
+      /*
+       * Minimum mass peak intensity (interpreted as relative abundance)
+       * threshold to trigger fraction collection
+       */
+      "mass_threshold": Float
+    }
+  }
+}
+```
+
+#### **Execution**
+Vendors are responsible for ensuring that specified parameters translate to successful operation, given the working ranges of available instruments. For example, the LC module must be capable of providing sufficient pressure to drive the sample through the column’s packed bed at the specified flowrate, given the operating temperature and the diameter of the column being used. Additionally, the `ion_source` and `mass_analyzer` will determine the type of mass spectrometer required by the instruction.
+
+The `gradient` should generally be set such that analyte is eluted off the column close to the midpoint of the run.
+
+#### **Compatibility**
+This is a new instruction; this addition does not pose compaibility issues for existing instructions.


### PR DESCRIPTION
A proposal to add an `lcms` instruction to represent the coupled liquid chromatography-mass spectrometry technique in Autoprotocol.