### PR TITLE
Add ASC proposal for `Image`

### DIFF
--- a/Proposed/asc048.md
+++ b/Proposed/asc048.md
@@ -1,0 +1,52 @@
+#### **Title**
+New instruction: `image`
+
+#### **Authorship**
+Asuka Ota <asuka.ota@strateos.com>
+
+Varun Kanwar <varunkanwar1@gmail.com>
+
+#### **Motivation**
+Imaging during the course of chemical and bioscience experiments provides valuable information about samples, such as opacity, color, dryness, crystal structure, and indicates microbial growth and the presence of contaminants. It is also useful as a tool to flag anomalies, and detect unexpected or unintended reactions. The currently-existing `image_plate` instruction offers limited support for these needs, and enables only top-down imagery of SBS-format plates. This ASC aims to support imaging of samples in containers with disparate shapes and well-formats, from several angles, and to provide some control over lighting conditions and magnification.
+
+#### **Proposal**
+We propose a versatile `image` instruction to allow for visible-light imaging operations on a broad range of container types.
+
+```
+{
+  “op”: “image”,
+  /* A plate, tube, vial, or bottle */
+  “object”: Container,
+  /* Angle of image capture */
+  “mode”: Enum(“top”, ”bottom”, “side”),
+  /* Number of images taken of the container. Optional; should default to 1 */
+  “num_images”: Int
+  /* Image data output */
+  “dataref”: Data,
+  /* Whether back-lighting is desired. Optional */
+  “back_lighting”: Boolean,
+  /* Parameters to control exposure. Optional */
+  “exposure”: {
+    /*
+     * Diameter of the lens opening. This controls the amount of light
+     * reaching the sensor. Optional
+     */
+    “aperture”: Float,
+    /* Light sensitivity of the imaging sensor. Optional */
+    “iso”: Float,
+    /* Duration that the imaging sensor is exposed to the scene. Optional */
+    “shutter_speed”: Time
+  },
+  /*
+   * Ratio of sizes of the image projected on the camera sensor, to
+   * the actual size of the object captured. Optional, should default to 1
+   */
+  “magnification”: Float
+}
+```
+
+#### **Execution**
+Vendors must ensure that devices present in the execution environment are capable of respecting specific magnification, exposure, and lighting parameters, and that optional parameters default to sensible values when unspecified.
+
+#### **Compatibility**
+This change is backwards compatible; the `image_plate` instruction will be deprecated separately in favor of this instruction.

--- a/Proposed/asc048.md
+++ b/Proposed/asc048.md
@@ -21,7 +21,7 @@ We propose a versatile `image` instruction to allow for visible-light imaging op
   “mode”: Enum(“top”, ”bottom”, “side”),
   /* Number of images taken of the container. Optional; should default to 1 */
   “num_images”: Int
-  /* Image data output */
+  /* Name of output data object */
   “dataref”: String,
   /* Whether back-lighting is desired. Optional */
   “back_lighting”: Boolean,

--- a/Proposed/asc048.md
+++ b/Proposed/asc048.md
@@ -22,7 +22,7 @@ We propose a versatile `image` instruction to allow for visible-light imaging op
   /* Number of images taken of the container. Optional; should default to 1 */
   “num_images”: Int
   /* Image data output */
-  “dataref”: Data,
+  “dataref”: String,
   /* Whether back-lighting is desired. Optional */
   “back_lighting”: Boolean,
   /* Parameters to control exposure. Optional */


### PR DESCRIPTION
A proposal to add an `image` instruction to Autoprotocol, to supplant the deprecated `image_plate` instruction.