### PR TITLE
feat: add flow_cytometry instruction

### DIFF
--- a/Published/asc049.md
+++ b/Published/asc049.md
@@ -1,0 +1,110 @@
+﻿#### **Title**
+Flow cytometry
+
+#### **Authorship**
+Peter Lee <peter@transcriptic.com>
+
+#### **Motivation**
+Flow cytometry is a common tool in life science.
+This instruction provides a non-ambiguous set of parameters for the performance of flow cytometry.
+
+#### **Proposal**
+
+```
+{
+  "op": "flow_cytometry",
+  "dataref": string,
+  "samples": [well],
+  "lasers": [
+    {
+      "excitation": wavelength,
+      /* laser power, optional */
+      "power": milliwatts,
+      /*
+       * value to scale height and area equivalently,
+       * optional
+       */
+      "area_scaling_factor": number,
+      "channels": [
+        {
+          /*
+           * wavelengths are not needed if channel
+           * name is FSC or SSC.
+           */
+          "emission_filter": {
+            "shortpass": wavelength,
+            "longpass": wavelength,
+            "channel_name": string,
+          },
+          "detector_gain": millivolts,
+          /*
+           * pulse properties to record
+           * optional, default: all true
+           * sub-properties are optional, default: true
+           */
+          "measurements": {
+            "area": boolean,
+            "height": boolean,
+            "width": boolean
+          },
+          /*
+           * channel intensity threshold,
+           * events below this threshold
+           * will not be recorded, optional
+           */
+          "trigger_threshold": integer,
+          /*
+           * operator used to combine threshold,
+           * optional, default: "and"
+           */
+          "trigger_logic": "and | or"
+        }
+      ]
+    }
+  ],
+  "collection_conditions": {
+    "acquisition_volume": volume,
+    "flowrate": flowrate,
+    /*
+     * end_conditions are combined,
+     * under "or" logic,
+     * optional, if left unset,
+     * the aquisition_volume will be used
+     * sub-properties are optional
+     */
+    "stop_criteria": {
+      "volume": volume,
+      "events": integer,
+      "time": time
+    },
+    "wait_time": time,
+    /* mixes before acquisition */
+    "mix_cycles": integer,
+    "mix_volume": volume,
+    /* rinses before acquisition */
+    "rinse_cycles": integer
+  },
+  /*
+   * threshold to determine width measurement,
+   * optional
+   */
+  "width_threshold": number,
+  /*
+   * front and rear window extension,
+   * optional
+   */
+  "window_extension": number,
+  /*
+   * remove coincident events,
+   * optional, default: false
+   */
+  "remove_coincident_events": boolean
+}
+```
+
+#### **Execution**
+For each `flow_cytometry` instruction, the channel information will be collected for each sample given the collection conditions specified.
+
+#### **Compatibility**
+This ASC only specifies new instructions.
+

--- a/Specification/Instructions/flow_cytometry.md
+++ b/Specification/Instructions/flow_cytometry.md
@@ -1,0 +1,51 @@
+#### **Description**
+Flow cytometry optically detects and characterizes particles suspended in a fluid.
+For each `flow_cytometry` instruction, the channel information will be collected for each sample given the collection conditions specified.
+`stop_criteria` are combined based on the condition specified in `trigger_logic`; if left unset, the aquisition_volume will be used.
+
+#### **Specification**
+{
+  "op": "flow_cytometry",
+  "dataref": String,
+  "samples": [Aliquot],
+  "lasers": [
+    {
+      "excitation": Option<Length>,
+      "power": Option<Power>,
+      "area_scaling_factor": Option<Float>,
+      "channels": [
+        {
+          "emission_filter": {
+            "shortpass": Option<Length>,
+            "longpass": Option<Length>,
+            "channel_name": String,
+          },
+          "detector_gain": ElectricPotential,
+          "measurements": Option<{
+            "area": Option<Boolean>,
+            "height": Option<Boolean>,
+            "width": Option<Boolean>
+          }>,
+          "trigger_threshold": Option<Int>,
+          "trigger_logic": Option<Enum("and", "or")>
+        }
+      ]
+    }
+  ],
+  "collection_conditions": {
+    "acquisition_volume": Volume,
+    "flowrate": VolumeFlow,
+    "stop_criteria": Option<{
+      "volume": Option<Volume>,
+      "events": Option<Int>,
+      "time": Option<Time>
+    }>,
+    "wait_time": Time,
+    "mix_cycles": Int,
+    "mix_volume": Volume,
+    "rinse_cycles": Int
+  },
+  "width_threshold": Option<Float>,
+  "window_extension": Option<Float>,
+  "remove_coincident_events": Option<Boolean>
+}


### PR DESCRIPTION
This instruction had been previously accepted but was not ported to this repository during the transition and had also not been assigned a number. This adds the instruction, assigns it a number, and adds spec for it.