### PR TITLE
Update Autoprotocol `Units` Definition

### DIFF
--- a/Proposed/update_units.md
+++ b/Proposed/update_units.md
@@ -1,0 +1,25 @@
+#### **Title**
+Update `Units` Definitions with units in use at Strateos
+
+#### **Authorship**
+Yang Choo yang.choo@strateos.com
+
+#### **Motivation**
+There are a number of units we have since adopted at Strateos for chemistry and biology purposes which are currently not present in the Autoprotocol specification.
+
+#### **Proposal**
+Add the following units
+- Acceleration: `millimeter/second^2`
+- ElectricPotential: `nanovolt`, `microvolt`
+- Frequency: `kilohertz`, `rpm`
+- Length: `nanometer`
+- Matter: `nanomole`
+- Power: `microwatt`, `milliwatt`
+- Pressure: `bar`, `torr`
+- Velocity: `millimeter/second`
+- Volume: `nanoliter`
+- VolumeAcceleration: `milliliter/second^2`
+- VolumeFlow: `milliliter/second`
+
+#### **Compatibility**
+No backwards compatibility issues as this is just adding new units.


### PR DESCRIPTION
There are a couple of units which we have seen use in Strateos which are
not currently present in the Autoprotocol units definition.

See ASC for more details.