### PR TITLE
feat: Publish liquid handle dispense mode

### DIFF
--- a/Published/asc054.md
+++ b/Published/asc054.md
@@ -2,10 +2,11 @@
 Add `dispense` mode to `liquid_handle` instruction
 
 # Authorship
-Rhys Ormond <rhys@transcriptic.com>
+Rhys Ormond <rhys.ormond@strateos.com>
+Peter Lee <peter.lee@strateos.com>
 
 # Motivation
-Devices such as reagent dispensers are configurable in many of the same ways that channel-based `air_displacement` liquid handlers are. The primary difference between them is a the concept of a flow of liquid between two aliquots.
+Devices such as reagent dispensers are configurable in many of the same ways that channel-based `air_displacement` liquid handlers are. The primary difference between them is the concept of a flow of liquid between two aliquots.
 
 # Proposal
 We propose the `dispense` mode for the `liquid_handle` instruction to represent the mode of liquid handling used by devices such as reagent dispensers.


### PR DESCRIPTION
This adds a new `dispense` mode for the `liquid_handle` instruction to the standard.

NOTE: The specification was already previously updated with this liquid handle mode so there are no updates needed there.