### PR TITLE
feat: Add new attribute `informatics`

### DIFF
--- a/Proposed/asc056.md
+++ b/Proposed/asc056.md
@@ -17,10 +17,10 @@ Instruction currently has `op`, and `data` attributes. We propose adding a new o
 specified in `informatics` with vendor LIMS systems. This `informatics` is an optional parameter that can accept a list 
 of effects for each instruction. `type` specifies the type of the effect, and `data` is a set of parameters to 
 describe the effect.   
-We are proposing to only add 'attach_compounds' at this time, but more types 
-may be available in the future such as 'purify_compounds', 'liquefy', etc. Here, `wells` is a list of aliquots that are 
-affected by the instruction. The instruction must directly operate on `wells` or its container to have any effects. 
-`compounds` is a list of compounds that will be attached to the `wells` (for 'attach_compounds').
+We are proposing to only add 'attach_compounds' at this time, but more types may be available in the future such as 
+'purify_compounds', 'liquefy', etc. Here, `wells` is a list of aliquots that are affected by the instruction. The 
+instruction must directly operate on `wells` or its container to have any effects. `compounds` is a list of compounds 
+that will be attached to the `wells` (for 'attach_compounds').
 
 ```
 "instructions": [

--- a/Proposed/asc056.md
+++ b/Proposed/asc056.md
@@ -17,7 +17,8 @@ Instruction currently has `op`, and `data` attributes. We propose adding a new a
 in our Autoprotocol schema to represent the intended effects of an instruction. A vendor may choose to integrate 
 the data specified in `informatics` with their internal LIMS systems. This `informatics` is an optional parameter 
 that can accept a list of effects for each instruction. `type` specifies the type of the effect, and `details` is a 
-set of parameters to describe the effect. We are proposing to only add 'attach_compounds' at this time, but more types 
+set of parameters to describe the effect.   
+We are proposing to only add 'attach_compounds' at this time, but more types 
 may be available in the future such as 'purify_compounds', 'liquefy', etc. Here, `refs` is a list of aliquots that are 
 affected by the instruction, and `compounds` is a list of compounds that will be attached to the `refs` (for 
 'attach_compounds').
@@ -27,6 +28,10 @@ affected by the instruction, and `compounds` is a list of compounds that will be
   {
     "op": String,
     ...,
+    /*
+     * optional parameter describing a list of intended effects or changes 
+     * for each instruction.
+     */
     "informatics": [
       {
         /* type of the effect. */
@@ -34,7 +39,7 @@ affected by the instruction, and `compounds` is a list of compounds that will be
         /* Details of the type. */
         "details": {
           "refs": List(Well) or WellGroup,
-          "compounds": List(String)
+          "compounds": List(Compound)
         }
       }
     ]

--- a/Proposed/asc056.md
+++ b/Proposed/asc056.md
@@ -18,10 +18,11 @@ in our Autoprotocol schema to represent the intended effects of an instruction. 
 the data specified in `informatics` with their internal LIMS systems. This `informatics` is an optional parameter 
 that can accept a list of effects for each instruction. `type` specifies the type of the effect, and `details` is a 
 set of parameters to describe the effect.   
+
 We are proposing to only add 'attach_compounds' at this time, but more types 
 may be available in the future such as 'purify_compounds', 'liquefy', etc. Here, `refs` is a list of aliquots that are 
-affected by the instruction, and `compounds` is a list of compounds that will be attached to the `refs` (for 
-'attach_compounds').
+affected by the instruction. The instruction must directly operate on `refs` or its container to have any effects. 
+`compounds` is a list of compounds that will be attached to the `refs` (for 'attach_compounds').
 
 ```
 "instructions": [

--- a/Proposed/asc056.md
+++ b/Proposed/asc056.md
@@ -1,0 +1,40 @@
+#### **Title**
+Add `informatics` to Autoprotocol instruction schema
+
+#### **Authorship**
+Asuka Ota <asuka.ota@strateos.com>
+
+#### **Motivation**
+In the current form, Autoprotocol is unable to capture a scientific intent at the molecular
+level upon execution of an `instruction`. One of the examples is pcr whereby a mixture of nucleotides
+and polymerase are mixed in a vial to synthesize new molecules via `thermocycle`. In another case, a user may want
+to purify a compound of interest from a mixture of compounds. In addition to the physical execution parameters, 
+there should be a set of parameters describing the intended effects of an instruction on the sample composition.
+
+#### **Proposal**
+Instruction currently has `op`, and `data` attributes. We propose adding a new attribute called `informatics` 
+in our Autoprotocol schema to represent the intended effects of an instruction. A vendor may choose to integrate 
+the data specified in `informatics` with their internal LIMS systems. This `informatics` is an optional parameter 
+that can accept a list of effects for each instruction. `type` specifies the type of the effect, and `details` is a 
+set of parameters to describe the effect. We are proposing to only add 'attach_compounds' at this time, but more types 
+may be available in the future such as 'purify_compounds', 'liquefy', etc. Here, `refs` is a list of aliquots that are 
+affected by the instruction, and `compounds` is a list of compounds that will be attached to the `refs` (for 
+'attach_compounds').
+
+```
+"informatics": [
+  {
+    /* type of the effect. */
+    "type": Enum("attach_compounds"),
+    /* Details of the type. */
+    "details": {
+      "refs": List(Well) or WellGroup,
+      "compounds": List(String)
+    }
+  }
+]
+```
+
+#### **Compatibility**
+This is a new optional attribute added to the existing schema. The `informatics` field should default to None
+value to continue executing instructions without `informatics`.

--- a/Proposed/asc056.md
+++ b/Proposed/asc056.md
@@ -8,8 +8,9 @@ Asuka Ota <asuka.ota@strateos.com>
 In the current form, Autoprotocol is unable to capture a scientific intent at the molecular
 level upon execution of an `instruction`. One of the examples is pcr whereby a mixture of nucleotides
 and polymerase are mixed in a vial to synthesize new molecules via `thermocycle`. In another case, a user may want
-to purify a compound of interest from a mixture of compounds. In addition to the physical execution parameters, 
-there should be a set of parameters describing the intended effects of an instruction on the sample composition.
+to purify a compound of interest from a mixture of compounds in instructions such as `spe` and/or `lcms`. In 
+addition to the physical execution parameters, there should be a set of parameters describing the intended effects 
+of an instruction on the sample composition.
 
 #### **Proposal**
 Instruction currently has `op`, and `data` attributes. We propose adding a new attribute called `informatics` 
@@ -22,15 +23,21 @@ affected by the instruction, and `compounds` is a list of compounds that will be
 'attach_compounds').
 
 ```
-"informatics": [
+"instructions": [
   {
-    /* type of the effect. */
-    "type": Enum("attach_compounds"),
-    /* Details of the type. */
-    "details": {
-      "refs": List(Well) or WellGroup,
-      "compounds": List(String)
-    }
+    "op": String,
+    ...,
+    "informatics": [
+      {
+        /* type of the effect. */
+        "type": Enum("attach_compounds"),
+        /* Details of the type. */
+        "details": {
+          "refs": List(Well) or WellGroup,
+          "compounds": List(String)
+        }
+      }
+    ]
   }
 ]
 ```

--- a/Proposed/asc056.md
+++ b/Proposed/asc056.md
@@ -5,24 +5,22 @@ Add `informatics` to Autoprotocol instruction schema
 Asuka Ota <asuka.ota@strateos.com>
 
 #### **Motivation**
-In the current form, Autoprotocol is unable to capture a scientific intent at the molecular
-level upon execution of an `instruction`. One of the examples is pcr whereby a mixture of nucleotides
-and polymerase are mixed in a vial to synthesize new molecules via `thermocycle`. In another case, a user may want
-to purify a compound of interest from a mixture of compounds in instructions such as `spe` and/or `lcms`. In 
-addition to the physical execution parameters, there should be a set of parameters describing the intended effects 
-of an instruction on the sample composition.
+In the current form, Autoprotocol is unable to capture scientific intent at the molecular level upon execution of an 
+`instruction`. One of the examples is PCR whereby a mixture of nucleotides and polymerase are mixed in a vial to 
+synthesize new molecules via `thermocycle`. In another case, a user may want to purify a compound of interest from 
+a mixture of compounds in instructions such as `spe` and/or `lcms`. In addition to the physical execution parameters, 
+there should be a set of parameters describing the intended effects of an instruction on the sample composition.
 
 #### **Proposal**
-Instruction currently has `op`, and `data` attributes. We propose adding a new attribute called `informatics` 
-in our Autoprotocol schema to represent the intended effects of an instruction. A vendor may choose to integrate 
-the data specified in `informatics` with their internal LIMS systems. This `informatics` is an optional parameter 
-that can accept a list of effects for each instruction. `type` specifies the type of the effect, and `details` is a 
-set of parameters to describe the effect.   
-
+Instruction currently has `op`, and `data` attributes. We propose adding a new optional attribute, `informatics,` to the 
+`Instruction` to represent the intended effects of an instruction. This may enable future integration of the data 
+specified in `informatics` with vendor LIMS systems. This `informatics` is an optional parameter that can accept a list 
+of effects for each instruction. `type` specifies the type of the effect, and `data` is a set of parameters to 
+describe the effect.   
 We are proposing to only add 'attach_compounds' at this time, but more types 
-may be available in the future such as 'purify_compounds', 'liquefy', etc. Here, `refs` is a list of aliquots that are 
-affected by the instruction. The instruction must directly operate on `refs` or its container to have any effects. 
-`compounds` is a list of compounds that will be attached to the `refs` (for 'attach_compounds').
+may be available in the future such as 'purify_compounds', 'liquefy', etc. Here, `wells` is a list of aliquots that are 
+affected by the instruction. The instruction must directly operate on `wells` or its container to have any effects. 
+`compounds` is a list of compounds that will be attached to the `wells` (for 'attach_compounds').
 
 ```
 "instructions": [
@@ -31,15 +29,15 @@ affected by the instruction. The instruction must directly operate on `refs` or 
     ...,
     /*
      * optional parameter describing a list of intended effects or changes 
-     * for each instruction.
+     * for this instruction.
      */
     "informatics": [
       {
         /* type of the effect. */
         "type": Enum("attach_compounds"),
         /* Details of the type. */
-        "details": {
-          "refs": List(Well) or WellGroup,
+        "data": {
+          "wells": List(Well) or WellGroup,
           "compounds": List(Compound)
         }
       }
@@ -49,5 +47,4 @@ affected by the instruction. The instruction must directly operate on `refs` or 
 ```
 
 #### **Compatibility**
-This is a new optional attribute added to the existing schema. The `informatics` field should default to None
-value to continue executing instructions without `informatics`.
+This is a new optional attribute to be added to the existing schema. The `informatics` field should default to None.

--- a/Proposed/asc056.md
+++ b/Proposed/asc056.md
@@ -5,27 +5,17 @@ Add `informatics` to Autoprotocol instruction schema
 Asuka Ota <asuka.ota@strateos.com>
 
 #### **Motivation**
-In the current form, Autoprotocol is unable to capture scientific intent at the molecular level upon execution of an 
-`instruction`. One of the examples is PCR whereby a mixture of nucleotides and polymerase are mixed in a vial to 
-synthesize new molecules via `thermocycle`. In another case, a user may want to purify a compound of interest from 
-a mixture of compounds in instructions such as `spe` and/or `lcms`. In addition to the physical execution parameters, 
-there should be a set of parameters describing the intended effects of an instruction on the sample composition.
+In the current form, Autoprotocol is unable to capture scientific intent at the molecular level upon execution of `instruction`. One of the examples is PCR whereby a mixture of nucleotides and polymerase are mixed in a vial to synthesize new molecules via `thermocycle`. In another case, a user may want to purify a compound of interest from a mixture of compounds in instructions such as `spe` and/or `lcms`. In addition to the physical execution parameters, there should be a set of parameters describing the intended effects of an instruction on the sample composition.
 
 #### **Proposal**
-Instruction currently has `op`, and `data` attributes. We propose adding a new optional attribute, `informatics,` to the 
-`Instruction` to represent the intended effects of an instruction. This may enable future integration of the data 
-specified in `informatics` with vendor LIMS systems. This `informatics` is an optional parameter that can accept a list 
-of effects for each instruction. `type` specifies the type of the effect, and `data` is a set of parameters to 
-describe the effect.   
-We are proposing to only add 'attach_compounds' at this time, but more types may be available in the future such as 
-'purify_compounds', 'liquefy', etc. Here, `wells` is a list of aliquots that are affected by the instruction. The 
-instruction must directly operate on `wells` or its container to have any effects. `compounds` is a list of compounds 
-that will be attached to the `wells` (for 'attach_compounds').
+Instruction currently has `op`, and `data` attributes. We propose adding a new optional attribute, `informatics,` to the `Instruction` to represent the intended effects of an instruction. This may enable future integration of the data specified in `informatics` with vendor LIMS. This `informatics` is an optional parameter that can accept a list of effects for each instruction. `type` specifies the type of the effect, and `data` is a set of parameters to describe the effect.   
+
+We are proposing to only add 'attach_compounds' at this time, but more types may be available in the future such as 'purify_compounds', 'liquefy', etc. Here, `wells` is a list of aliquots that are affected by the instruction. The instruction must directly operate on `wells` or its container to have any effects. `compounds` is a list of compounds that will be attached to the `wells` (for 'attach_compounds').
 
 ```
 "instructions": [
   {
-    "op": String,
+    "op": String
     ...,
     /*
      * optional parameter describing a list of intended effects or changes 


### PR DESCRIPTION
This proposal adds new optional set of parameters `informatics` to the Instruction schema. This will be used to indicate the scientific intent of an instruction at the molecular level, such as generation of a new compound, which may be captured in aliquot properties by the vendor.
* We are proposing to add a new attribute `informatics` with `type` and `details` parameters.
