### PR TITLE
feat: add informatics to LH and provision

### DIFF
--- a/Proposed/asc057.md
+++ b/Proposed/asc057.md
@@ -1,0 +1,32 @@
+#### **Title**
+Add optional `informatics` param to `provision`
+
+#### **Authorship**
+Asuka Ota <asuka.ota@strateos.com>
+
+Mixing multiple reactive compounds in a vial can sometimes generate new compound, even under an ambient condition. `provision` is one of such instructions which may introduce a reactive compound to an aliquot. To be able to specify such effects at the instructional level, a new optional parameter `informatics` should be added.
+
+#### **Proposal**
+Add an optional `informatics` parameter to `provision`. The data schema for `informatics` was previously defined in `asc056`.
+
+```
+{
+  "op": "provision",
+  /* 
+   * optional parameter to indicate intended effect `type` from this instruction, and its description
+   * in `data`.
+   */
+  "informatics": [
+    {
+      "type": Enum("attach_compounds"),
+      "data": {
+        "wells": List(Well) or WellGroup
+        "compounds": List(Compound)
+    }
+  ],
+  ...
+}
+```
+
+#### **Compatibility**
+This is a new optional parameter added to the existing schema. The `informatics` should default to None.

--- a/Proposed/asc058.md
+++ b/Proposed/asc058.md
@@ -1,0 +1,32 @@
+#### **Title**
+Add optional `informatics` param to `liquid_handle`
+
+#### **Authorship**
+Asuka Ota <asuka.ota@strateos.com>
+
+Mixing multiple reactive compounds in a vial can sometimes generate new compound, even under an ambient condition. `liquid_handle` is one of such instructions which may introduce a reactive compound to an aliquot. To be able to specify such effects at the instructional level, a new optional parameter `informatics` should be added.
+
+#### **Proposal**
+Add an optional `informatics` parameter to `liquid_handle`. The data schema for `informatics` was previously defined in `asc056`.
+
+```
+{
+  "op": "liquid_handle",
+  /* 
+   * optional parameter to indicate intended effect `type` from this instruction, and its description
+   * in `data`.
+   */
+  "informatics": [
+    {
+      "type": Enum("attach_compounds"),
+      "data": {
+        "wells": List(Well) or WellGroup
+        "compounds": List(Compound)
+    }
+  ],
+  ...
+}
+```
+
+#### **Compatibility**
+This is a new optional parameter added to the existing schema. The `informatics` should default to None.


### PR DESCRIPTION
Proposal to add a new `informatics` param optionally to `provision` and `liquid_handle`. 
Please see [asc056](https://github.com/autoprotocol/ascs/blob/master/Proposed/asc056.md) for more info.